### PR TITLE
[bugfix] Handle missing arguments exception

### DIFF
--- a/src/ArgvResolver.php
+++ b/src/ArgvResolver.php
@@ -19,6 +19,7 @@ use Yannoff\Component\Console\Definition\Argument;
 use Yannoff\Component\Console\Definition\Option;
 use Yannoff\Component\Console\Exception\Definition\ArgumentNotSetException;
 use Yannoff\Component\Console\Exception\Definition\InvalidOptionTypeException;
+use Yannoff\Component\Console\Exception\Definition\MissingArgumentsException;
 use Yannoff\Component\Console\Exception\Definition\UndefinedArgumentException;
 use Yannoff\Component\Console\Exception\Definition\UndefinedOptionException;
 use Yannoff\Component\Console\Exception\ResolverException;
@@ -211,6 +212,7 @@ class ArgvResolver
     public function resolve($argv = [])
     {
         $argc = 0;
+        $expectedArgs = $this->definition->getMandatoryArgs();
 
         // Iterate over command-line arguments and populate options/arguments accordingly
         while (null !== ($pos = key($argv))) {
@@ -266,6 +268,7 @@ class ArgvResolver
                         }
                         $name = $this->definition->getNameByPosition('arguments', $argc);
                         $this->arguments[$name] = $arg;
+                        unset($expectedArgs[$name]);
                         $argc++;
                         break;
                 endswitch;
@@ -278,6 +281,11 @@ class ArgvResolver
                 $this->stderr->write($error);
             }
             next($argv);
+        }
+
+        // If some mandatory arguments are missing from command invocation, raise fatal exception
+        if (count($expectedArgs) > 0) {
+            throw new MissingArgumentsException($expectedArgs);
         }
     }
 

--- a/src/Definition/Item.php
+++ b/src/Definition/Item.php
@@ -79,6 +79,16 @@ abstract class Item
     abstract public static function getValidTypes();
 
     /**
+     * Default to-string type-cast conversion for Item objects
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->name;
+    }
+
+    /**
      * Check whether the given type as a valid value
      *
      * @param int $type

--- a/src/Exception/Definition/MissingArgumentsException.php
+++ b/src/Exception/Definition/MissingArgumentsException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the yannoff/console library
  * (c) Yannoff (https://github.com/yannoff)

--- a/src/Exception/Definition/MissingArgumentsException.php
+++ b/src/Exception/Definition/MissingArgumentsException.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\Exception\Definition;
+
+use Exception;
+use Yannoff\Component\Console\Definition\Argument;
+use Yannoff\Component\Console\Exception\FatalException;
+use Yannoff\Component\Console\Exception\ResolverException;
+
+/**
+ * Class MissingArgumentsException
+ *
+ * Thrown by ArgvResolver when some missing arguments identified (not supplied by the user which have no default value)
+ *
+ * @package Yannoff\Component\Console\Exception\Definition
+ */
+class MissingArgumentsException extends FatalException implements ResolverException
+{
+    /**
+     * @var Argument[]
+     */
+    protected $args;
+
+    /**
+     * MissingArgumentsException constructor.
+     *
+     * @param Argument[]     $args     List of the missing queried arguments (one or more)
+     * @param int            $code     Error status code to be sent to the terminal (defaults to 128)
+     * @param Exception|null $previous Optional parent exception
+     */
+    public function __construct($args = [], $code = 128, Exception $previous = null)
+    {
+        $this->args = $args;
+
+        // Force automatic type-casting thanks to the Argument::__toString() method
+        $names = implode(', ', $args);
+
+        $message = sprintf('One or more mandatory args where not supplied (and have no default value): [%s]', $names);
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Getter for the missing arguments
+     *
+     * @return Argument[]
+     */
+    public function getArguments()
+    {
+        return $this->args;
+    }
+}

--- a/src/Exception/FatalException.php
+++ b/src/Exception/FatalException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the yannoff/console library
  * (c) Yannoff (https://github.com/yannoff)

--- a/src/Exception/FatalException.php
+++ b/src/Exception/FatalException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\Exception;
+
+/**
+ * Class FatalException
+ * Represent a blocking exception: when raised code execution should terminate
+ *
+ * @package Yannoff\Component\Console\Exception
+ */
+class FatalException extends RuntimeException
+{
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        return sprintf('Fatal: %s (code: %s)', $this->message, $this->code);
+    }
+}

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the yannoff/console library
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console;
+
+use Exception;
+use Yannoff\Component\Console\Exception\Definition\MissingArgumentsException;
+use Yannoff\Component\Console\IO\StreamAware;
+
+/**
+ * Class ExceptionHandler
+ * Handler for all kinds of exceptions
+ *
+ * @package Yannoff\Component\Console
+ */
+class ExceptionHandler
+{
+    /**
+     * Handler method for runtime exceptions
+     *
+     * @param Exception   $exception The thrown exception
+     * @param StreamAware $callee    The object calling this method
+     *
+     * @return int The exception status code
+     */
+    public static function process(Exception $exception, StreamAware $callee)
+    {
+        $type = get_class($exception);
+
+        switch ($type):
+            case MissingArgumentsException::class:
+                /** @var MissingArgumentsException $exception */
+                foreach ($exception->getArguments() as $arg) {
+                    $error = sprintf('%s: Missing argument "%s".', 'Error', $arg);
+                    $callee->error($error);
+                }
+                break;
+
+            default:
+                $error = sprintf('%s: %s.', 'Error', $exception->getMessage());
+                $callee->error($error);
+                break;
+        endswitch;
+
+        return $exception->getCode();
+    }
+}

--- a/src/IO/StreamAware.php
+++ b/src/IO/StreamAware.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the yannoff/console library
+ *
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\IO;
+
+/**
+ * Interface StreamAware
+ * Represent objects with stream interaction capabilities
+ *
+ * @package Yannoff\Component\Console\IO
+ */
+interface StreamAware
+{
+    /**
+     * Print text to STDERR
+     *
+     * @param string $text   The text to print (defaults to empty string)
+     * @param string $ending Ending character or text
+     *
+     * @return bool|int
+     */
+    public function error($text = '', $ending = ASCII::LF);
+
+    /**
+     * Print text to STDOUT
+     *
+     * @param string $text   The text to print (defaults to empty string)
+     * @param string $ending Ending character or text
+     *
+     * @return bool|int
+     */
+    public function write($text = '', $ending = ASCII::LF);
+
+    /**
+     * Read contents from the standard input
+     *
+     * @param bool $interactive Whether to accept user input
+     *
+     * @return string|false The contents or **false** in case of failure
+     */
+    public function read($interactive = false);
+}


### PR DESCRIPTION
Resolves #9 & #11

- `ArgvResolver`: Detect missing mandatory args
- `Item`: Implement default to-string type-cast
- `Command`: Handle missing arg exception nicely