### PR TITLE
Allow calling text output methods without args

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -243,12 +243,12 @@ abstract class Command extends StreamAware implements FormatterAware
     /**
      * Print text to STDOUT
      *
-     * @param string $text    The text to print
+     * @param string $text    The text to print (defaults to empty string)
      * @param null   $options Kept for symfony BC, but ignored
      *
      * @return bool|int
      */
-    public function writeln($text, $options = null)
+    public function writeln($text = '', $options = null)
     {
         $text = $this->getFormatter()->format($text);
 
@@ -258,12 +258,12 @@ abstract class Command extends StreamAware implements FormatterAware
     /**
      * Print text to STDERR
      *
-     * @param string $text    The text to print
+     * @param string $text    The text to print (defaults to empty string)
      * @param null   $options Kept for symfony BC, but ignored
      *
      * @return bool|int
      */
-    public function errorln($text, $options = null)
+    public function errorln($text = '', $options = null)
     {
         $text = $this->getFormatter()->format($text);
 

--- a/src/IO/StreamAwareTrait.php
+++ b/src/IO/StreamAwareTrait.php
@@ -41,12 +41,12 @@ trait StreamAwareTrait
     /**
      * Print a message to standard output with the given ending string
      *
-     * @param string $message The message to print
+     * @param string $message The message to print (defaults to empty string)
      * @param string $ending  The ending string (defaults to "\n")
      *
      * @return int|false Number of bytes written or **false** on error
      */
-    public function iowrite($message, $ending = Formatter::LF)
+    public function iowrite($message = '', $ending = Formatter::LF)
     {
         $writer = StreamInitializer::getWriter($this, IOStream::STDOUT);
 
@@ -56,12 +56,12 @@ trait StreamAwareTrait
     /**
      * Print a message to standard error with the given ending char
      *
-     * @param string $message The message to print
+     * @param string $message The message to print (defaults to empty string)
      * @param string $ending  The ending string (defaults to "\n")
      *
      * @return int|false Number of bytes written or **false** on error
      */
-    public function ioerror($message, $ending = Formatter::LF)
+    public function ioerror($message = '', $ending = Formatter::LF)
     {
         $writer = StreamInitializer::getWriter($this, IOStream::STDERR);
 


### PR DESCRIPTION
Set default text value to empty string for:
- `Command::writeln()`
- `Command::errorln()`
- `StreamAwareTrait::ioerror()`
- `StreamAwareTrait::iowrite()`

Resolves #13 