### PR TITLE
Improve IO Stream Wrappers

### DIFF
--- a/src/Exception/IO/StreamLogicException.php
+++ b/src/Exception/IO/StreamLogicException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) 2019 Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\Exception\IO;
+
+use Yannoff\Component\Console\Exception\LogicException;
+
+/**
+ * Class StreamLogicException
+ *
+ * Generic exception for stream-related logic inconsistencies
+ *
+ * @package Yannoff\Component\Console\Exception\IO
+ */
+class StreamLogicException extends LogicException
+{
+
+}

--- a/src/Exception/IO/UnsupportedStreamException.php
+++ b/src/Exception/IO/UnsupportedStreamException.php
@@ -14,7 +14,6 @@
 namespace Yannoff\Component\Console\Exception\IO;
 
 use Exception;
-use Yannoff\Component\Console\Exception\LogicException;
 
 /**
  * Class UnsupportedStreamException
@@ -23,7 +22,7 @@ use Yannoff\Component\Console\Exception\LogicException;
  *
  * @package Yannoff\Component\Console\Exception\IO
  */
-class UnsupportedStreamException extends LogicException
+class UnsupportedStreamException extends StreamLogicException
 {
     /**
      * UnsupportedStreamException constructor.

--- a/src/Exception/UndefinedConstantException.php
+++ b/src/Exception/UndefinedConstantException.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) 2019 Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\Exception;
+
+use Exception;
+
+/**
+ * Class UndefinedConstantException
+ *
+ * Thrown by ConstantAccessor::get() when queried class constant is not defined
+ *
+ * @package Yannoff\Component\Console\Exception
+ */
+class UndefinedConstantException extends LogicException
+{
+    /**
+     * Name of the undefined constant
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Name of the class supposed to define the constant
+     *
+     * @var string
+     */
+    protected $target;
+
+    /**
+     * UndefinedConstantException constructor.
+     *
+     * @param string         $name     Name of the undefined constant
+     * @param string         $target   Class the constant should be found in
+     * @param int            $code     Error status code to be sent to the terminal (defaults to 1)
+     * @param Exception|null $previous Optional parent in exception chaining
+     */
+    public function __construct($name = '', $target = '', $code = 1, Exception $previous = null)
+    {
+        $this->name = $name;
+        $this->target = $target;
+
+        $message = sprintf('Undefined "%s::%s" class constant', $target, $name);
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Getter for the $name property
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Getter for the $target property
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->target;
+    }
+}

--- a/src/IO/ConstantAccessor.php
+++ b/src/IO/ConstantAccessor.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) 2019 Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\IO;
+
+use Yannoff\Component\Console\Exception\UndefinedConstantException;
+
+/**
+ * Class ConstantAccessor
+ *
+ * Allow access to class constants
+ *
+ * @package Yannoff\Component\Console\IO
+ */
+class ConstantAccessor
+{
+    /**
+     * Generic getter for class constants
+     *
+     * @param string $name   Name of the class constant
+     * @param string $target Target class (defaults to *static*)
+     *
+     * @return mixed
+     * @throws UndefinedConstantException If the queried class constant is not defined
+     */
+    public static function get($name = '', $target = 'static')
+    {
+        $constant = sprintf('%s::%s', $target, $name);
+
+        if (!defined($constant)) {
+            throw new UndefinedConstantException($name, $target);
+        }
+
+        return constant($constant);
+    }
+}

--- a/src/IO/Stream/IOStream.php
+++ b/src/IO/Stream/IOStream.php
@@ -29,4 +29,12 @@ interface IOStream
     const STDIN = 'stdin';
     const STDOUT = 'stdout';
     const STDERR = 'stderr';
+
+    /**
+     * Available modes for fopen()
+     *
+     * @var string
+     */
+    const APPEND = 'a+';
+    const READONLY = 'r';
 }

--- a/src/IO/Stream/StandardError.php
+++ b/src/IO/Stream/StandardError.php
@@ -15,23 +15,22 @@ namespace Yannoff\Component\Console\IO\Stream;
 
 /**
  * Class StandardError
+ *
  * Writer stream for standard error (STDERR)
  *
  * @package Yannoff\Component\Console\IO\Stream
  */
-class StandardError implements IOWriter
+class StandardError extends Wrapper implements IOWriter
 {
     /**
      * The stream short name
      */
-    const NAME = IOStream::STDERR;
+    const NAME = self::STDERR;
 
     /**
-     * Handle to the writable stream
-     *
-     * @var resource
+     * The stream open mode
      */
-    protected $handle = STDERR;
+    const MODE = self::APPEND;
 
     /**
      * {@inheritdoc}

--- a/src/IO/Stream/StandardInput.php
+++ b/src/IO/Stream/StandardInput.php
@@ -15,23 +15,22 @@ namespace Yannoff\Component\Console\IO\Stream;
 
 /**
  * Class StandardInput
+ *
  * Reader stream for standard input (STDIN)
  *
  * @package Yannoff\Component\Console\IO\Stream
  */
-class StandardInput implements IOReader
+class StandardInput extends Wrapper implements IOReader
 {
     /**
      * The stream short name
      */
-    const NAME = IOStream::STDIN;
+    const NAME = self::STDIN;
 
     /**
-     * Handle to the stream to read from
-     *
-     * @var bool|resource
+     * The stream open mode
      */
-    protected $handle = STDIN;
+    const MODE = self::READONLY;
 
     /**
      * {@inheritdoc}

--- a/src/IO/Stream/StandardOutput.php
+++ b/src/IO/Stream/StandardOutput.php
@@ -15,23 +15,22 @@ namespace Yannoff\Component\Console\IO\Stream;
 
 /**
  * Class StandardOutput
+ *
  * Writer stream for standard output (STDOUT)
  *
  * @package Yannoff\Component\Console\IO\Stream
  */
-class StandardOutput implements IOWriter
+class StandardOutput extends Wrapper implements IOWriter
 {
     /**
      * The stream short name
      */
-    const NAME = IOStream::STDOUT;
+    const NAME = self::STDOUT;
 
     /**
-     * Handle to the writable stream
-     *
-     * @var resource
+     * The stream open mode
      */
-    protected $handle = STDOUT;
+    const MODE = self::APPEND;
 
     /**
      * {@inheritdoc}

--- a/src/IO/Stream/Wrapper.php
+++ b/src/IO/Stream/Wrapper.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This file is part of the yannoff/console library
+ * (c) 2019 Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\IO\Stream;
+
+use Yannoff\Component\Console\Exception\IO\StreamLogicException;
+use Yannoff\Component\Console\Exception\UndefinedConstantException;
+use Yannoff\Component\Console\IO\ConstantAccessor;
+
+/**
+ * Class Wrapper
+ *
+ * Super-class for PHP I/O Stream wrappers (both writers & readers)
+ *
+ * @package Yannoff\Component\Console\IO\Stream
+ */
+class Wrapper
+{
+    /**
+     * Handle to the stream wrapper
+     *
+     * @var resource
+     */
+    protected $handle;
+
+    /**
+     * Wrapper constructor.
+     */
+    public function __construct()
+    {
+        $this->bind();
+    }
+
+    /**
+     * Wrapper destructor
+     * Free the stream handle resource
+     */
+    public function __destruct()
+    {
+        $this->free();
+    }
+
+    /**
+     * Bind the wrapper stream resource
+     */
+    protected function bind()
+    {
+        $this->handle = fopen($this->getURI(), $this->getOpenMode());
+    }
+
+    /**
+     * Unbind the wrapper stream resource
+     */
+    protected function free()
+    {
+        is_resource($this->handle) && fclose($this->handle);
+    }
+
+    /**
+     * Build the PHP stream wrapper URI using the child class NAME constant
+     *
+     * @return string
+     */
+    public function getURI()
+    {
+        $wrapper = $this->constant('NAME');
+
+        return sprintf('php://%s', $wrapper);
+    }
+
+    /**
+     * Build the PHP stream wrapper fopen() mode using the child class MODE constant
+     *
+     * @return string
+     */
+    public function getOpenMode()
+    {
+        return $this->constant('MODE');
+    }
+
+    /**
+     * Generic getter for Wrapper child classes constants
+     *
+     * @param string $name The class constant name
+     *
+     * @return mixed
+     * @throws StreamLogicException If the queried constant is not defined
+     */
+    protected function constant($name = '')
+    {
+        try {
+            return ConstantAccessor::get($name, static::class);
+        } catch (UndefinedConstantException $e) {
+            $message = sprintf('Classes extending "%s" must have the "%s" constant defined', __CLASS__, $e->getName());
+            throw new StreamLogicException($message);
+        }
+    }
+}


### PR DESCRIPTION
- Implement `Wrapper` superclass
- Rework wrapper streams binding
    - Populate `$handle` via `fopen('php://stdxxx')` instead of `STDIN` / `STDOUT` / `STDERR`
    - Call `fclose()` on `$handle` property at destruction to ensure the resource is freed
  
Should fix #15 