### PR TITLE
Amend legal banner

### DIFF
--- a/bin/demo
+++ b/bin/demo
@@ -2,11 +2,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/ArgvResolver.php
+++ b/src/ArgvResolver.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Command.php
+++ b/src/Command.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Definition/Item.php
+++ b/src/Definition/Item.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Definition/Option.php
+++ b/src/Definition/Option.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Command/UnknownCommandException.php
+++ b/src/Exception/Command/UnknownCommandException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/ArgumentNotSetException.php
+++ b/src/Exception/Definition/ArgumentNotSetException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/InvalidArgumentTypeException.php
+++ b/src/Exception/Definition/InvalidArgumentTypeException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/InvalidOptionTypeException.php
+++ b/src/Exception/Definition/InvalidOptionTypeException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/TooManyArgumentsException.php
+++ b/src/Exception/Definition/TooManyArgumentsException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/UndefinedArgumentException.php
+++ b/src/Exception/Definition/UndefinedArgumentException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/UndefinedOptionException.php
+++ b/src/Exception/Definition/UndefinedOptionException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/Definition/UnknownOptionException.php
+++ b/src/Exception/Definition/UnknownOptionException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/DefinitionException.php
+++ b/src/Exception/DefinitionException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/IO/StreamLogicException.php
+++ b/src/Exception/IO/StreamLogicException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/IO/UnsupportedStreamException.php
+++ b/src/Exception/IO/UnsupportedStreamException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ResolverException.php
+++ b/src/Exception/ResolverException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/UndefinedConstantException.php
+++ b/src/Exception/UndefinedConstantException.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/ConstantAccessor.php
+++ b/src/IO/ConstantAccessor.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/CygwinFormatter.php
+++ b/src/IO/Output/CygwinFormatter.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/FlatFormatter.php
+++ b/src/IO/Output/FlatFormatter.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/Formatter.php
+++ b/src/IO/Output/Formatter.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/FormatterAware.php
+++ b/src/IO/Output/FormatterAware.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/FormatterAwareTrait.php
+++ b/src/IO/Output/FormatterAwareTrait.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/FormatterFactory.php
+++ b/src/IO/Output/FormatterFactory.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Output/PosixFormatter.php
+++ b/src/IO/Output/PosixFormatter.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/PropertyAccessor.php
+++ b/src/IO/PropertyAccessor.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/IOReader.php
+++ b/src/IO/Stream/IOReader.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/IOStream.php
+++ b/src/IO/Stream/IOStream.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/IOWriter.php
+++ b/src/IO/Stream/IOWriter.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/StandardError.php
+++ b/src/IO/Stream/StandardError.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/StandardInput.php
+++ b/src/IO/Stream/StandardInput.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/StandardOutput.php
+++ b/src/IO/Stream/StandardOutput.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/Stream/Wrapper.php
+++ b/src/IO/Stream/Wrapper.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/StreamAware.php
+++ b/src/IO/StreamAware.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/StreamAwareTrait.php
+++ b/src/IO/StreamAwareTrait.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/StreamFactory.php
+++ b/src/IO/StreamFactory.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/IO/StreamInitializer.php
+++ b/src/IO/StreamInitializer.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Tests/Command/HelloCommand.php
+++ b/src/Tests/Command/HelloCommand.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * This file is part of the yannoff/console library
- * (c) 2019 Yannoff (https://github.com/yannoff)
+ * (c) Yannoff (https://github.com/yannoff)
  *
  * @project   yannoff/console
  * @link      https://github.com/yannoff/console
- * @license   http://opensource.org/licenses/MIT
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
- Remove copyright year: from now on, copyright date range will be on the LICENSE file only
- License tag now points to the project's LICENSE file instead of the generic MIT link