### PR TITLE
[refactor] Rework `help` command output

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -280,10 +280,13 @@ abstract class Command extends StreamAware implements FormatterAware
         $lines = [];
         $lines[] = $this->getSynopsis();
         foreach (['arguments', 'options'] as $bag) {
-            $lines[] = sprintf("<strong>%s</strong>", ucfirst($bag));
             try {
-                foreach ($this->definition->all($bag) as $name => $item) {
-                    $lines[] = $item->getSynopsis();
+                $definitions = $this->definition->all($bag);
+                if (count($definitions) > 0) {
+                    $lines[] = sprintf("<strong>%s</strong>", ucfirst($bag));
+                    foreach ($definitions as $name => $item) {
+                        $lines[] = $item->getSynopsis();
+                    }
                 }
             } catch (LogicException $e) {
                 // DefinitionException should never raise in this context,
@@ -293,7 +296,7 @@ abstract class Command extends StreamAware implements FormatterAware
             }
         }
 
-        $out = implode("\n", $lines) . "\n";
+        $out = implode(Formatter::LF, $lines) . Formatter::LF;
 
         return $out;
     }
@@ -305,7 +308,9 @@ abstract class Command extends StreamAware implements FormatterAware
      */
     protected function getSynopsis()
     {
-        $message = "<strong>Usage</strong>\n\t%s %s [options] [--] %s\n<strong>Description</strong>\n\t%s";
+        $nl = Formatter::LF;
+        $sep = $nl . Formatter::TAB;
+        $message = "<strong>Usage</strong>" . $sep . "%s %s [options] [--] %s" . $nl . "<strong>Description</strong>" . $sep . "%s";
 
         return sprintf($message, $this->application->getScript(), $this->name, $this->definition->getArgSynopsis(), $this->help);
     }

--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -14,6 +14,7 @@
 namespace Yannoff\Component\Console\Definition;
 
 use Yannoff\Component\Console\Exception\Definition\InvalidArgumentTypeException;
+use Yannoff\Component\Console\IO\Output\Formatter;
 
 /**
  * Class Argument
@@ -101,7 +102,7 @@ class Argument extends Item
      */
     public function getSynopsis()
     {
-        $help = sprintf("\t%-18s %s", $this->name, $this->help);
+        $help = sprintf("%s%-18s %s", Formatter::TAB, $this->name, $this->help);
 
         if ($this->hasDefault()) {
             $help .= sprintf(' (default: <strong>%s</strong>)', $this->default);

--- a/src/Definition/Option.php
+++ b/src/Definition/Option.php
@@ -14,6 +14,7 @@
 namespace Yannoff\Component\Console\Definition;
 
 use Yannoff\Component\Console\Exception\Definition\InvalidOptionTypeException;
+use Yannoff\Component\Console\IO\Output\Formatter;
 
 /**
  * Class Option
@@ -128,7 +129,7 @@ class Option extends Item
             $synopsis .= sprintf(' %s', 'VALUE');
         }
 
-        $help = sprintf("\t%-18s %s", $synopsis, $this->help);
+        $help = sprintf("%s%-18s %s", Formatter::TAB, $synopsis, $this->help);
 
         if ($this->hasDefault()) {
             $help .= sprintf(' (default: <strong>%s</strong>)', $this->default);

--- a/src/IO/Output/Formatter.php
+++ b/src/IO/Output/Formatter.php
@@ -40,6 +40,20 @@ interface Formatter
     const CRLF = "\r\n";
 
     /**
+     * Tabulation character
+     *
+     * @var string
+     */
+    const TAB = "\t";
+
+    /**
+     * Soft-tab string: 4 spaces
+     *
+     * @var string
+     */
+    const STAB = "    ";
+
+    /**
      * Render the given markup text into a terminal-compatible format
      *
      * @param string $text The pre-formatted text to be rendered


### PR DESCRIPTION
- Use `Formatter::*` class constants for control characters
- Don't display `Arguments` / `Options` sections when empty