### PR TITLE
[refactor] Rework usage rendering methods design

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -270,19 +270,24 @@ class Application extends StreamAware implements FormatterAware
     /**
      * Build application usage/help message upon the registered commands and return it
      *
+     * @param string $tab   The tabulation string (defaults to `\n`)
+     * @param int    $width Minimum width for the command names column (defaults to `18`)
+     *
      * @return string
      */
-    public function getUsage()
+    public function getUsage($tab = Formatter::TAB, $width = Formatter::PAD)
     {
         $lines = [];
+
         $lines[] = "<strong>Usage</strong>";
-        $lines[] = sprintf("\t%s <command> [<options>] -- [<arguments>]", $this->script);
+        $lines[] = sprintf("${tab}%s <command> [<options>] -- [<arguments>]", $this->script);
         $lines[] = "<strong>Commands</strong>";
+
         foreach ($this->commands as $name => $command) {
-            $lines[] = sprintf("\t%-18s  %s", $name, $command->getHelp());
+            $lines[] = sprintf("${tab}%-{$width}s  %s", $name, $command->getHelp());
         }
 
-        return implode("\n", $lines);
+        return implode(Formatter::LF, $lines);
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -275,19 +275,27 @@ abstract class Command extends StreamAware implements FormatterAware
     /**
      * Build the whole command usage/help message with all options/arguments documented
      *
+     * @param string $tab   The tabulation string (defaults to `\n`)
+     * @param int    $width Minimum width for the option/argument names column (defaults to `18`)
+     *
      * @return string
      */
-    public function getUsage()
+    public function getUsage($tab = Formatter::TAB, $width = Formatter::PAD)
     {
         $lines = [];
-        $lines[] = $this->getSynopsis();
+
+        $lines[] = "<strong>Usage</strong>";
+        $lines[] = $this->getSynopsis($tab);
+        $lines[] = "<strong>Description</strong>";
+        $lines[] = $tab . $this->help;
+
         foreach (['arguments', 'options'] as $bag) {
             try {
                 $definitions = $this->definition->all($bag);
                 if (count($definitions) > 0) {
                     $lines[] = sprintf("<strong>%s</strong>", ucfirst($bag));
                     foreach ($definitions as $name => $item) {
-                        $lines[] = $item->getSynopsis();
+                        $lines[] = $item->getSynopsis($tab, $width);
                     }
                 }
             } catch (LogicException $e) {
@@ -298,23 +306,21 @@ abstract class Command extends StreamAware implements FormatterAware
             }
         }
 
-        $out = implode(Formatter::LF, $lines) . Formatter::LF;
-
-        return $out;
+        return implode(Formatter::LF, $lines) . Formatter::LF;
     }
 
     /**
      * Get the command synopsis
      *
+     * @param string $tab The tabulation string (defaults to `\n`)
+     *
      * @return string
      */
-    protected function getSynopsis()
+    protected function getSynopsis($tab = Formatter::TAB)
     {
-        $nl = Formatter::LF;
-        $sep = $nl . Formatter::TAB;
-        $message = "<strong>Usage</strong>" . $sep . "%s %s [options] [--] %s" . $nl . "<strong>Description</strong>" . $sep . "%s";
+        $format = "{$tab}%s %s [options] [--] %s";
 
-        return sprintf($message, $this->application->getScript(), $this->name, $this->definition->getArgSynopsis(), $this->help);
+        return sprintf($format, $this->application->getScript(), $this->name, $this->definition->getArgSynopsis());
     }
 
     /**

--- a/src/Definition/Argument.php
+++ b/src/Definition/Argument.php
@@ -102,9 +102,9 @@ class Argument extends Item
     /**
      * {@inheritdoc}
      */
-    public function getSynopsis()
+    public function getSynopsis($tab = Formatter::TAB, $width = Formatter::PAD)
     {
-        $help = sprintf("%s%-18s %s", Formatter::TAB, $this->name, $this->help);
+        $help = sprintf("%s%-${width}s %s", $tab, $this->name, $this->help);
 
         if ($this->hasDefault()) {
             $help .= sprintf(' (default: <strong>%s</strong>)', $this->default);

--- a/src/Definition/Item.php
+++ b/src/Definition/Item.php
@@ -15,6 +15,8 @@
 
 namespace Yannoff\Component\Console\Definition;
 
+use Yannoff\Component\Console\IO\Output\Formatter;
+
 /**
  * Class Item
  * Super-class for both Option & Argument
@@ -61,9 +63,12 @@ abstract class Item
     /**
      * Return the formatted help for the item
      *
+     * @param string $tab The tabulation string (defaults to `\n`)
+     * @param int    $width Minimum width for the names column (defaults to `18`)
+     *
      * @return string
      */
-    abstract public function getSynopsis();
+    abstract public function getSynopsis($tab = Formatter::TAB, $width = Formatter::PAD);
 
     /**
      * Give the authorized values for the type property

--- a/src/Definition/Option.php
+++ b/src/Definition/Option.php
@@ -123,7 +123,7 @@ class Option extends Item
     /**
      * {@inheritdoc}
      */
-    public function getSynopsis()
+    public function getSynopsis($tab = Formatter::TAB, $width = Formatter::PAD)
     {
         $synopsis = implode(', ', $this->getNames());
 
@@ -131,7 +131,7 @@ class Option extends Item
             $synopsis .= sprintf(' %s', 'VALUE');
         }
 
-        $help = sprintf("%s%-18s %s", Formatter::TAB, $synopsis, $this->help);
+        $help = sprintf("%s%-${width}s %s", $tab, $synopsis, $this->help);
 
         if ($this->hasDefault()) {
             $help .= sprintf(' (default: <strong>%s</strong>)', $this->default);

--- a/src/IO/Output/Formatter.php
+++ b/src/IO/Output/Formatter.php
@@ -56,6 +56,11 @@ interface Formatter
     const STAB = "    ";
 
     /**
+     * Minimal left-padding width for the name columns in help
+     */
+    const PAD = 18;
+
+    /**
      * Render the given markup text into a terminal-compatible format
      *
      * @param string $text The pre-formatted text to be rendered


### PR DESCRIPTION
- Make tabulation & name column width configurable in all usage rendering methods
- Method `Command::getSynopsis()` now only return the synopsis line (possible BC break)