### PR TITLE
[dependencies] Remove useless `phpcs` dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,9 @@
             "homepage": "https://github.com/yannoff"
         }
     ],
-    "require": {},
     "autoload": {
         "psr-4": {
             "Yannoff\\Component\\Console\\": "src/"
         }
-    },
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.4"
     }
 }


### PR DESCRIPTION
Since 2079de290fe4cfb62a6a19b29582eb85c762cbc3, code style checking is now handled by the github workflow,
there is no more need for the `squizlabs/php_codesniffer` dev package