### PR TITLE
[Formatter] Fix BC break in `format()` signature

### DIFF
--- a/src/IO/Output/Formatter.php
+++ b/src/IO/Output/Formatter.php
@@ -69,5 +69,5 @@ interface Formatter
      *
      * @return string
      */
-    public function format($text, $fd);
+    public function format($text, $fd = null);
 }

--- a/src/IO/Output/PosixFormatter.php
+++ b/src/IO/Output/PosixFormatter.php
@@ -49,7 +49,7 @@ class PosixFormatter implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($text, $fd)
+    public function format($text, $fd = null)
     {
         // In case of a piped output, return a raw text
         if (! posix_isatty($fd)) {


### PR DESCRIPTION
Fixes #36 