### PR TITLE
[Formatter] Consolidate tag parsing engine

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -260,7 +260,7 @@ class Application
         $lines = [];
 
         $lines[] = "<strong>Usage</strong>";
-        $lines[] = sprintf("{$tab}%s <command> [<options>] -- [<arguments>]", $this->script);
+        $lines[] = sprintf("{$tab}%s <command> [options] [--] [arguments]", $this->script);
         $lines[] = "<strong>Commands</strong>";
 
         foreach ($this->getUserCommands() as $name => $command) {

--- a/src/IO/Output/Posix/AtomicTag.php
+++ b/src/IO/Output/Posix/AtomicTag.php
@@ -25,29 +25,6 @@ namespace Yannoff\Component\Console\IO\Output\Posix;
 class AtomicTag
 {
     /**
-     * Mapping between pseudo-tags and terminal modifiers
-     */
-    protected $tags = [
-        'strong'   => '01m',
-        'black'    => '00;30m',
-        'grey'     => '01;30m',
-        'red'      => '00;31m',
-        'green'    => '00;32m',
-        'yellow'   => '00;33m',
-        'blue'     => '00;34m',
-        'magenta'  => '00;35m',
-        'cyan'     => '00;36m',
-        'white'    => '00;37m',
-        'default'  => '00m',
-        // A few Symfony Console formatter compatible tags
-        'bold'     => '01m',
-        'error'    => '00;31m',
-        'info'     => '00;32m',
-        'comment'  => '00;33m',
-        'question' => '00;36m',
-    ];
-
-    /**
      * The tag name
      *
      * @var string
@@ -86,7 +63,7 @@ class AtomicTag
         
         $this->type = ($tag[0] == '/')  ? 'close' : 'open';
         $this->name = \trim($tag, '/');
-        $this->modifier = $this->tags[$this->name];
+        $this->modifier = TagMap::get($this->name);
     }
 
     /**

--- a/src/IO/Output/Posix/TagMap.php
+++ b/src/IO/Output/Posix/TagMap.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the yannoff/console library
+ *
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * @project   yannoff/console
+ * @link      https://github.com/yannoff/console
+ * @license   https://github.com/yannoff/console/blob/master/LICENSE
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yannoff\Component\Console\IO\Output\Posix;
+
+use Yannoff\Component\Console\Exception\LogicException;
+
+/**
+ * Class TagMap
+ *
+ * Map pseudo-tags and terminal modifiers
+ *
+ * @package Yannoff\Component\Console\IO\Output\Posix
+ */
+class TagMap
+{
+    /**
+     * Mapping between pseudo-tags and terminal modifiers
+     */
+    static protected $tags = [
+        'strong'   => '01m',
+        'black'    => '00;30m',
+        'grey'     => '01;30m',
+        'red'      => '00;31m',
+        'green'    => '00;32m',
+        'yellow'   => '00;33m',
+        'blue'     => '00;34m',
+        'magenta'  => '00;35m',
+        'cyan'     => '00;36m',
+        'white'    => '00;37m',
+        'default'  => '00m',
+        // A few Symfony Console formatter compatible tags
+        'bold'     => '01m',
+        'error'    => '00;31m',
+        'info'     => '00;32m',
+        'comment'  => '00;33m',
+        'question' => '00;36m',
+    ];
+
+    /**
+     * Check whether the given tag is supported
+     *
+     * @param string $tag The tag name
+     *
+     * @return bool
+     */
+    public static function has($tag)
+    {
+        return \array_key_exists($tag, self::$tags);
+    }
+
+    /**
+     * Get the terminal modifier associated with the given tag
+     *
+     * @param string $tag The tag name
+     *
+     * @return string
+     *
+     * @throws LogicException If the queried tag is unknown
+     */
+    public static function get($tag)
+    {
+        if (! self::has($tag)) {
+            $error = \sprintf('Unsupported "%s" tag', $tag);
+            throw new LogicException($error);
+        }
+        
+        return self::$tags[$tag];
+    }
+}

--- a/src/IO/Output/PosixFormatter.php
+++ b/src/IO/Output/PosixFormatter.php
@@ -113,6 +113,8 @@ class PosixFormatter implements Formatter
         // Use the ASCII bell character to prevent collision with text contents
         $text = preg_replace('/>(.)/', ">\b\$1", $text);
         $text = preg_replace('/(.)</', "\$1\b<", $text);
+        // New lines must be considered as separate tokens
+        $text = preg_replace("/\n/", "\b\n\b", $text);
         $lines = explode("\b",  $text);
 
         return array_map(function ($line) { return new Token($line); }, $lines);

--- a/src/IO/Output/Token.php
+++ b/src/IO/Output/Token.php
@@ -15,6 +15,8 @@
 
 namespace Yannoff\Component\Console\IO\Output;
 
+use Yannoff\Component\Console\IO\Output\Posix\TagMap;
+
 /**
  * Class Token
  *
@@ -52,7 +54,10 @@ class Token
      */
     public function isTag()
     {
-        return \preg_match('/^</', \ltrim($this->raw));
+        $spaceless = \ltrim($this->raw);
+        $trimmed = \trim($spaceless, '></');
+
+        return \preg_match('/^</', $spaceless) && TagMap::has($trimmed);
     }
 
     /**


### PR DESCRIPTION
- Evaluate `LF` chars as separate tokens
- Only process supported tags

Fixes #55 